### PR TITLE
BACKLOG-15447: Changing the pom the minimal should be 8.0.1.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>jahia-packages-parent</artifactId>
         <groupId>org.jahia.packages</groupId>
-        <version>8.0.0.0</version>
+        <version>8.0.1.0</version>
     </parent>
     <artifactId>jahia-starter-template-package</artifactId>
     <name>Jahia Starter Template Package</name>
@@ -66,12 +66,12 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>jahia-starter-template</artifactId>
-            <version>0.1.0</version>
+            <version>0.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>page-builder-components</artifactId>
-            <version>0.1.0</version>
+            <version>0.2.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-15447

## Description

Trivial change to update the pom to 8.0.1.0
Updated the package to point to v0.2.0 of the site-builder-template-component. (Will update to SNAPSHOT first if needed)